### PR TITLE
Don't recomend StrictHostKeyChecking=no

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Scope:
       TCPKeepAlive=yes
       ServerAliveInterval=15
       ServerAliveCountMax=6
-      StrictHostKeyChecking=no
       Compression=yes
       ForwardAgent=yes
 ```


### PR DESCRIPTION
This makes Secure Shell mostly just a Shell, leaving you open to MITMs that you will never notice.