### PR TITLE
Mention the standard movement bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Scope:
 
 - In bash, use **ctrl-r** to search through command history.
 
-- In bash, use **ctrl-w** to delete the last word, and **ctrl-u** to delete the whole line. Use **alt-Left** and **alt-Right** to move by word, and **ctrl-k** to kill to the end of the line. See `man readline` for all the default keybindings in bash. There are a lot. For example **alt-.** cycles through previous arguments, and **alt-*** expands a glob.
+- In bash, use **ctrl-w** to delete the last word, and **ctrl-u** to delete the whole line. Use **alt-f** and **alt-b** to move by word, and **ctrl-k** to kill to the end of the line. See `man readline` for all the default keybindings in bash. There are a lot. For example **alt-.** cycles through previous arguments, and **alt-*** expands a glob.
 
 - To go back to the previous working directory: `cd -`
 


### PR DESCRIPTION
By default, shells tend to follow the emacs bindings.

Using left/right arrow keys is not the standard in emacs/vim. Instead,
`ctrl-f`/`alt-f` and `ctrl-b`/`alt-b` are available for moving
forward/backward by a character/word respectively.