### PR TITLE
Use 80 as width, not filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ A few examples of piecing together commands:
           pandoc -f markdown -t html |
           xmlstarlet fo --html --dropdtd |
           xmlstarlet sel -t -v "(html/body/ul/li[count(p)>0])[$RANDOM mod last()+1]" |
-          xmlstarlet unesc | fmt 80
+          xmlstarlet unesc | fmt -80
       }
 ```
 


### PR DESCRIPTION
In trying the `taocl` function I get the error

```shell
$ taocl
fmt: cannot open ‘80’ for reading: No such file or directory
```

Looks like the final phrase should use the `80` as an option, ... `| fmt -80` (or `| fmt --width=80`)