### PR TITLE
Yum is being deprecated in favor of DNF, add a mention of dnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Scope:
 
 - Know regular expressions well, and the various flags to `grep`/`egrep`. The `-i`, `-o`, `-A`, and `-B` options are worth knowing.
 
-- Learn to use `apt-get` or `yum` (depending on distro) to find and install packages. And make sure you have `pip` to install Python-based command-line tools (a few below are easiest to install via `pip`).
+- Learn to use `apt-get`, `yum`, or `dnf` (depending on distro) to find and install packages. And make sure you have `pip` to install Python-based command-line tools (a few below are easiest to install via `pip`).
 
 
 ## Everyday use


### PR DESCRIPTION
Fedora 22 directs users to use DNF by default now.

http://dnf.baseurl.org/2015/05/11/yum-is-dead-long-live-dnf/