### PR TITLE
Changed incorrect alt command to ctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Scope:
 
 - In Bash, use **ctrl-r** to search through command history.
 
-- In Bash, use **ctrl-w** to delete the last word, and **ctrl-u** to delete the whole line. Use **alt-Left** and **alt-Right** to move by word, and **ctrl-k** to kill to the end of the line. See `man readline` for all the default keybindings in Bash. There are a lot. For example **alt-.** cycles through previous arguments, and **alt-*** expands a glob.
+- In Bash, use **ctrl-w** to delete the last word, and **ctrl-u** to delete the whole line. Use **ctrl-Left** and **ctrl-Right** to move by word, and **ctrl-k** to kill to the end of the line. See `man readline` for all the default keybindings in Bash. There are a lot. For example **alt-.** cycles through previous arguments, and **alt-*** expands a glob.
 
 - To go back to the previous working directory: `cd -`
 


### PR DESCRIPTION
the default command to move by word left or right is the control key.  This was previously listed as the alt key.