### PR TITLE
Added ssh options to multiplex channels to the same server

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Scope:
       Compression=yes
 ```
 
+- To lower network overhead, this `~/.ssh/config` contains settings to multiplex channels to the same server with a local control file:
+```
+      ControlMaster auto
+      ControlPath /tmp/%r@%h:%p
+      ControlPersist yes
+```
+
 - A few other options relevant to ssh are security sensitive and should be enabled with care, e.g. per subnet or host or in trusted networks: `StrictHostKeyChecking=no`, `ForwardAgent=yes`
 
 - To get the permissions on a file in octal form, which is useful for system configuration but not available in `ls` and easy to bungle, use something like

--- a/README.md
+++ b/README.md
@@ -105,16 +105,12 @@ Scope:
 
 - In ssh, knowing how to port tunnel with `-L` or `-D` (and occasionally `-R`) is useful, e.g. to access web sites from a remote server.
 
-- It can be useful to make a few optimizations to your ssh configuration; for example, this `~/.ssh/config` contains settings to avoid dropped connections in certain network environments, and use compression (which is helpful with scp over low-bandwidth connections):
+- It can be useful to make a few optimizations to your ssh configuration; for example, this `~/.ssh/config` contains settings to avoid dropped connections in certain network environments, use compression (which is helpful with scp over low-bandwidth connections), and multiplex channels to the same server with a local control file:
 ```
       TCPKeepAlive=yes
       ServerAliveInterval=15
       ServerAliveCountMax=6
       Compression=yes
-```
-
-- To lower network overhead, this `~/.ssh/config` contains settings to multiplex channels to the same server with a local control file:
-```
       ControlMaster auto
       ControlPath /tmp/%r@%h:%p
       ControlPersist yes


### PR DESCRIPTION
These settings in ~/.ssh/config make it easier to use ssh as suggested in the other commands.