### PR TITLE
Python 3 support for http.server

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,14 @@ Scope:
 
 - For interaction with files based on the output of another command (like `git`), use `fpp` ([PathPicker](https://github.com/facebook/PathPicker)).
 
-- For a simple web server for all files in the current directory (and subdirs), available to anyone on your network, use:
+- For a simple web server for all files in the current directory (and subdirs), available to anyone on your network, with python2 use:
 ```
       python -m SimpleHTTPServer [port]
+```
+
+- If you have python3:
+```
+      python -m http.server [port]
 ```
 
 ## Processing files and data


### PR DESCRIPTION
If you have installed python3 as default version, python -m SimpleHTTPServer won't work, it was replaced with http.server in the new version