### PR TITLE
Disk, sed, netstat -tulpn

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Scope:
 
 - Use `nohup` or `disown` if you want a background process to keep running forever.
 
-- Check what processes are listening via `netstat -tulpn`.
+- Check what processes are listening via `netstat -tulpn` or `ss -a`.
 
 - See also `lsof` for open sockets and files.
 


### PR DESCRIPTION
Disk management.
Alternative sed line for find/replace (makes more sense due to mentioning in awk section).
Optimized netstat line for listening ports (netstat -tulpn) -tulpn, is easier to remember because of the pronunciation, and it adds a -u flag, which also shows listening UDP ports. Not only TCP ports (-t). Or ss -a, for a more modern way.