### PR TITLE
Added "pv" to "Obscure but useful"

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ A few examples of piecing together commands:
 
 - `comm`: compare sorted files line by line
 
+- `pv`: monitor the progress of data through a pipe
+
 - `hd` and `bvi`: dump or edit binary files
 
 - `strings`: extract text from binary files


### PR DESCRIPTION
From the manpage:

       A simple example to watch how quickly a file is transferred using nc(1):

              pv file | nc -w 1 somewhere.com 3000

       A similar example, transferring a file from another process and passing the expected size to pv:

              cat file | pv -s 12345 | nc -w 1 somewhere.com 3000

       A more complicated example using numeric output to feed into the dialog(1) program for a full-screen progress display:

              (tar cf - . \
               | pv -n -s $(du -sb . | awk '{print $1}') \
               | gzip -9 > out.tgz) 2>&1 \
               | dialog --gauge 'Progress' 7 70

       Taking an image of a disk, skipping errors:

              pv -EE /dev/sda > disk-image.img

       Writing an image back to a disk:

              pv disk-image.img > /dev/sda

       Zeroing a disk:

              pv < /dev/zero > /dev/sda

       Note that if the input size cannot be calculated, and the output is a block device, then the size of the block device will be used and pv will automatically stop at that size as if -S had been given.

       (Linux only): Watching file descriptor 3 opened by another process 1234:

              pv -d 1234:3

       (Linux only): Watching all file descriptors used by process 1234:

              pv -d 1234
