### PR TITLE
(macos) adds mdls to "obscure but useful commands"

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ A few examples of piecing together commands:
 
 - `file`: identify type of a file
 
+- `mdls`: lists metadata of files like author or camera
+
 - `tree`: display directories and subdirectories as a nesting tree; like `ls` but recursive
 
 - `stat`: file info


### PR DESCRIPTION
mdls lists metdata of all kind of files like
thx to: http://www.askdavetaylor.com/can-i-analyze-exif-information-on-the-mac-os-x-command-line/