### PR TITLE
du -hs instead of -sk

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Notes:
 
 - Know `ssh`, and the basics of passwordless authentication, via `ssh-agent`, `ssh-add`, etc.
 
-- Basic file management: `ls` and `ls -l` (in particular, learn what every column in `ls -l` means), `less`, `head`, `tail` and `tail -f` (or even better, `less +F`), `ln` and `ln -s` (learn the differences and advantages of hard versus soft links), `chown`, `chmod`, `du` (for a quick summary of disk usage: `du -sk *`). For filesystem management, `df`, `mount`, `fdisk`, `mkfs`, `lsblk`.
+- Basic file management: `ls` and `ls -l` (in particular, learn what every column in `ls -l` means), `less`, `head`, `tail` and `tail -f` (or even better, `less +F`), `ln` and `ln -s` (learn the differences and advantages of hard versus soft links), `chown`, `chmod`, `du` (for a quick summary of disk usage: `du -hk *`). For filesystem management, `df`, `mount`, `fdisk`, `mkfs`, `lsblk`.
 
 - Basic network management: `ip` or `ifconfig`, `dig`.
 


### PR DESCRIPTION
`du -hs *` is more human readable.

```
bash-3.2$ du -sk *
3472	Applications
26192	Desktop
202752	Documents
1425520	Downloads
8374932	Dropbox


bash-3.2$ du -hs *
3.4M	Applications
 26M	Desktop
198M	Documents
1.4G	Downloads
8.0G 	Dropbox
```