### PR TITLE
Add alternative to `fpp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Notes:
 
 - For interactive selection of values from the output of another command, use [`percol`](https://github.com/mooz/percol) or [`fzf`](https://github.com/junegunn/fzf).
 
-- For interaction with files based on the output of another command (like `git`), use `fpp` ([PathPicker](https://github.com/facebook/PathPicker)).
+- For interaction with files based on the output of another command (like `git`), use `fpp` ([PathPicker](https://github.com/facebook/PathPicker)) or `pe + fzf.` ([pe: path extractor](https://github.com/edi9999/path-extractor))
 
 - For a simple web server for all files in the current directory (and subdirs), available to anyone on your network, use:
 `python -m SimpleHTTPServer 7777` (for port 7777 and Python 2) and `python -m http.server 7777` (for port 7777 and Python 3).


### PR DESCRIPTION
I'm using the alternative to fpp which is https://github.com/edi9999/path-extractor and fzf, and works very well for me.
I'm the creator of https://github.com/edi9999/path-extractor, so I don't know if you are going te be willing to accept this pull request.
