### PR TITLE
Include invert-match flag for grep.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Notes:
 
 - Basic network management: `ip` or `ifconfig`, `dig`.
 
-- Know regular expressions well, and the various flags to `grep`/`egrep`. The `-i`, `-o`, `-A`, and `-B` options are worth knowing.
+- Know regular expressions well, and the various flags to `grep`/`egrep`. The `-i`, `-o`, `-v`, `-A`, and `-B` options are worth knowing.
 
 - Learn to use `apt-get`, `yum`, `dnf` or `pacman` (depending on distro) to find and install packages. And make sure you have `pip` to install Python-based command-line tools (a few below are easiest to install via `pip`).
 


### PR DESCRIPTION
I'd argue that the -v (--invert-match) flag is as important a flag as -o (no offense to -o). Can't tell you how many times I've tailed a logfile and piped it through grep -v to filter out stuff I knew was legit or common.