### PR TITLE
Python one liner and cat fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A few examples of piecing together commands:
 ```
 
 - Find out the name,version and codename of your Linux OS distribution with Python
+
 `python -c 'from platform import dist; print dist()'`
 
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ A few examples of piecing together commands:
 
 - Say you have a text file, like a web server log, and a certain value that appears on some lines, such as an `acct_id` parameter that is present in the URL. If you want a tally of how many requests for each `acct_id`:
 ```sh
-      cat access.log | egrep -o 'acct_id=[0-9]+' | cut -d= -f2 | sort | uniq -c | sort -rn
+      egrep -o 'acct_id=[0-9]+' access.log | cut -d= -f2 | sort | uniq -c | sort -rn
 ```
 
 - Run this function to get a random tip from this document (parses Markdown and extracts an item):

--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ A few examples of piecing together commands:
       }
 ```
 
+- Find out the name,version and codename of your Linux OS distribution with Python
+`python -c 'from platform import dist; print dist()'`
+
 
 ## Obscure but useful
 


### PR DESCRIPTION
- Modify 'useless use of cat'
- Add Python one liner to get Linux distribution info