### PR TITLE
Added example of backreferences in Perl one-liners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,32 @@ Notes:
       perl -pi.bak -e 's/old-string/new-string/g' my-files-*.txt
 ```
 
+- To strip URLs from surrounding HTML:
+```sh
+    $ cat example.html 
+    Some text <a href="http://example.com/roar.mp3">Lion roar</a> So cool!<br/>
+    More stuff <a href="http://example.com/bird.mp3">Bird call</a>Pretty<br/>
+    No link on this line.
+    Some text <a href="http://example.com/crickets.mp3">Crickets</a>Relaxing.<br/>
+    Some text <a href="http://example.com/beach.mp3">Ocean waves.</a>Meditate!<br/>
+    More junk.
+
+    $ perl -ne 'print if s/^.*href="([^"]+)".*$/$1/' example.html 
+    http://example.com/roar.mp3
+    http://example.com/bird.mp3
+    http://example.com/crickets.mp3
+    http://example.com/beach.mp3
+
+    # Make a script to download all the files.
+    $ perl -ne 'print if s/^.*href="([^"]+)".*$/wget $1/' example.html > download.sh
+
+    $ cat download.sh 
+    wget http://example.com/roar.mp3
+    wget http://example.com/bird.mp3
+    wget http://example.com/crickets.mp3
+    wget http://example.com/beach.mp3
+```
+
 - To rename many files at once according to a pattern, use `rename`. For complex renames, [`repren`](https://github.com/jlevy/repren) may help.
 ```sh
       # Recover backup files foo.bak -> foo:

--- a/README.md
+++ b/README.md
@@ -250,6 +250,22 @@ Notes:
 
 - Use `zless`, `zmore`, `zcat`, and `zgrep` to operate on compressed files.
 
+- To see text output nicely aligned, use `column`:
+```sh
+ $ cat names.txt 
+ First Last Nickname
+ Kimberly Jones Kimmie
+ Robert Smith Bob
+ Christina Alvarez Tina
+ Manuel Santana Manny
+
+  $ column -t names.txt 
+  First      Last     Nickname
+  Kimberly   Jones    Kimmie
+  Robert     Smith    Bob
+  Christina  Alvarez  Tina
+  Manuel     Santana  Manny
+```
 
 ## System debugging
 


### PR DESCRIPTION
May help address #115. However, a brief tutorial in Perl-compatible regular expressions would be cool also. There are plenty of those online, so a link to a good one (and Jeffrey Friedl's [excellent book](http://amzn.com/0596528124) would be good. I wouldn't mind writing more Perl one-liner regex examples.