### PR TITLE
Excuting a script file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Notes:
 
 - Learn basic Bash. Actually, type `man bash` and at least skim the whole thing; it's pretty easy to follow and not that long. Alternate shells can be nice, but Bash is powerful and always available (learning *only* zsh, fish, etc., while tempting on your own laptop, restricts you in many situations, such as using existing servers).
 
+- For executing a script file, use `sh script-filename` or `./script-filename` or `source script-filename` or `. script-filename`, and you should know the differences.
+
 - Learn at least one text-based editor well. Ideally Vim (`vi`), as there's really no competition for random editing in a terminal (even if you use Emacs, a big IDE, or a modern hipster editor most of the time).
 
 - Know how to read documentation with `man` (for the inquisitive, `man man` lists the section numbers, e.g. 1 is "regular" commands, 5 is files/conventions, and 8 are for administration). Find man pages with `apropos`. Know that some commands are not executables, but Bash builtins, and that you can get help on them with `help` and `help -d`.


### PR DESCRIPTION
For executing a script file, you could use `sh script-filename` or `./script-filename` or `source script-filename` or `. script-filename`. The following are the differences:

 - `./script-filename` is identical to `sh script-filename`, excepting the script file should has execute permission, and the commands executed are in a subshell.
 - `source script-filename` executes the script file within the current context.
 - `. script-filename` is alias to `source script-filename`

Hope this is useful.