### PR TITLE
The easy way to redirect both standard output and standard error

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Notes:
 
 - Know about "here documents" in Bash, as in `cat <<EOF ...`.
 
-- In Bash, redirect both standard output and standard error via: `some-command >logfile 2>&1`. Often, to ensure a command does not leave an open file handle to standard input, tying it to the terminal you are in, it is also good practice to add `</dev/null`.
+- In Bash, redirect both standard output and standard error via: `some-command >logfile 2>&1` or `some-command &>logfile`. Often, to ensure a command does not leave an open file handle to standard input, tying it to the terminal you are in, it is also good practice to add `</dev/null`.
 
 - Use `man ascii` for a good ASCII table, with hex and decimal values. For general encoding info, `man unicode`, `man utf-8`, and `man latin1` are helpful.
 


### PR DESCRIPTION
I always use this method to redirect both standard output and standard error, it's more simple and clear than the old way.