### PR TITLE
zh: update taocl for chinese language

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -319,8 +319,9 @@ mkdir empty && rsync -r --delete empty/ some-dir && rmdir some-dir
 - 运行这个函数从这篇文档中随机获取一条技巧（解析 Markdown 文件并抽取项目）：
 ```sh
       function taocl() {
-        curl -s https://raw.githubusercontent.com/jlevy/the-art-of-command-line/master/README.md |
+        curl -s https://raw.githubusercontent.com/jlevy/the-art-of-command-line/master/README-zh.md|
           pandoc -f markdown -t html |
+          iconv -f 'utf-8' -t 'unicode' |
           xmlstarlet fo --html --dropdtd |
           xmlstarlet sel -t -v "(html/body/ul/li[count(p)>0])[$RANDOM mod last()+1]" |
           xmlstarlet unesc | fmt -80


### PR DESCRIPTION
1.  change curl target to 'https://raw.githubusercontent.com/jlevy/the-art-of-command-line/master/README-zh.md'
2.  fix chinese utf-8 encoding error by add iconv step.

commit id: ce77a04dc54a69d05221449397dac3adf165fb88