### PR TITLE
Remove duplicate shuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,8 +452,6 @@ A few examples of piecing together commands:
 
 - `tac`: print files in reverse
 
-- `shuf`: random selection of lines from a file
-
 - `comm`: compare sorted files line by line
 
 - `strings`: extract text from binary files


### PR DESCRIPTION
The `shuf` is mentioned two times. One can be maybe removed.