### PR TITLE
Update `apt-get` to `apt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Scope:
 
 Notes:
 
-- To keep this to one page, content is implicitly included by reference. You're smart enough to look up more detail elsewhere once you know the idea or command to Google. Use `apt-get`, `yum`, `dnf`, `pacman`, `pip` or `brew` (as appropriate) to install new programs.
+- To keep this to one page, content is implicitly included by reference. You're smart enough to look up more detail elsewhere once you know the idea or command to Google. Use `apt`, `yum`, `dnf`, `pacman`, `pip` or `brew` (as appropriate) to install new programs.
 - Use [Explainshell](http://explainshell.com/) to get a helpful breakdown of what commands, options, pipes etc. do.
 
 


### PR DESCRIPTION
I suggest that updating `apt-get` to `apt` because the latter is more *up-to-date* . Most of `apt-get` and `apt-cache` 's commands are available on `apt` in a more *user-friendly* way. Check [this](https://lists.debian.org/debian-devel/2014/04/msg00013.html) out.