### PR TITLE
Add ctrl-d to exit/logout bash/zsh/dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Notes:
 
 - If you are halfway through typing a command but change your mind, hit **alt-#** to add a `#` at the beginning and enter it as a comment (or use **ctrl-a**, **#**, **enter**). You can then return to it later via command history.
 
+- Use **ctrl-d** instead of typing `exit`; especially helpful on remote ssh sessions.
+
 - Use `xargs` (or `parallel`). It's very powerful. Note you can control how many items execute per line (`-L`) as well as parallelism (`-P`). If you're not sure if it'll do the right thing, use `xargs echo` first. Also, `-I{}` is handy. Examples:
 ```bash
       find . -name '*.py' | xargs grep some_function


### PR DESCRIPTION
I use **ctrl-d** often with `ssh` and `docker` instead of `exit` or `logout`. Works in `bash`, `zsh`, and `sh` AKA `dash`.  Especially helpful when you have run `ssh` to a bastion host, `ssh` to a misbehaving container host, `sudo` to root, and `docker exec` into a container.