### PR TITLE
Add `recode` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ mkdir empty && rsync -r --delete empty/ some-dir && rmdir some-dir
 
 - For binary diffs (delta compression), use `xdelta3`.
 
-- To convert text encodings, try `iconv`. Or `uconv` for more advanced use; it supports some advanced Unicode things. For example:
+- To convert text encodings, try `iconv` or `recode`. Or `uconv` for more advanced use; it supports some advanced Unicode things. For example:
 ```sh
       # Displays hex codes or actual names of characters (useful for debugging):
       uconv -f utf-8 -t utf-8 -x '::Any-Hex;' < input.txt
@@ -474,7 +474,7 @@ A few examples of piecing together commands:
 
 - `tr`: character translation or manipulation
 
-- `iconv` or `uconv`: conversion for text encodings
+- `iconv`, `recode` or `uconv`: conversion for text encodings
 
 - `split` and `csplit`: splitting files
 


### PR DESCRIPTION
Add `recode` to README.md.

The `[recode](https://github.com/rrthomas/recode/)` program is a handy front-end to the [recode library](https://github.com/rrthomas/recode/) that converts files between character sets and usages. It recognizes or produces over 200 different character sets (or about 300 if combined with an `iconv` library) and transliterates files between almost any pair. When exact transliteration are not possible, it gets rid of offending characters or falls back on approximations.