### PR TITLE
en: Fix description of `env` and add description of `eval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,9 @@ A few examples of piecing together commands:
 
 - `cal`: nice calendar
 
-- `env`: run a command (useful in scripts)
+- `env`: run a program in a modified environment
+
+- `eval`: run a string as command in a subshell (useful in scripts)
 
 - `printenv`: print out environment variables (useful in debugging and scripts)
 


### PR DESCRIPTION
**Main changes**: The description of `env` was the one of `eval`. It has been modified so that both appear correctly.

**About translations**: I can submit PRs for French, Spanish, Italian and German if this one is approved. 