### PR TITLE
Add mkfifo for namedpipes on obscure section

### DIFF
--- a/README-it.md
+++ b/README-it.md
@@ -495,6 +495,8 @@ Qualche esempio di combinazione di più comandi comandi:
 
 - `fortune`, `ddate`, e `sl`: mmmh, beh, dipende molto da quanto consideri le locomotive a vapore e le citazioni di Zippy "utili".
 
+- `mkfifo`: crea una namedpipe, utile per comunicazioni tra processi, due processi separati possono accedervi per nome e scriverci dati o leggervi 
+
 
 ## OS X
 

--- a/README.md
+++ b/README.md
@@ -548,6 +548,8 @@ A few examples of piecing together commands:
 
 - `fortune`, `ddate`, and `sl`: um, well, it depends on whether you consider steam locomotives and Zippy quotations "useful"
 
+- `mkfifo`: create a `namedpipe`, useful for inter-process communication, where two separate processes can access it by name and read/write into it
+
 
 ## macOS only
 

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ A few examples of piecing together commands:
 
 - `fortune`, `ddate`, and `sl`: um, well, it depends on whether you consider steam locomotives and Zippy quotations "useful"
 
-- `mkfifo`: create a `namedpipe`, useful for inter-process communication, where two separate processes can access it by name and read/write into it
+- `mkfifo`: create a namedpipe, useful for inter-process communication, where two separate processes can access it by name and read/write into it
 
 
 ## macOS only


### PR DESCRIPTION
`mkfifo` allows IPC and some lesser known tricks like 

`mkfifo /tmp/pipe && nc -l 12345 0</tmp/pipe | nc <address> <port> 1>/tmp/pipe` 

to setup a basic proxy (from https://en.wikipedia.org/wiki/Netcat#Proxying).