### PR TITLE
Suggest apt instead of apt-get

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Notes:
 
 - Know regular expressions well, and the various flags to `grep`/`egrep`. The `-i`, `-o`, `-v`, `-A`, `-B`, and `-C` options are worth knowing.
 
-- Learn to use `apt-get`, `yum`, `dnf` or `pacman` (depending on distro) to find and install packages. And make sure you have `pip` to install Python-based command-line tools (a few below are easiest to install via `pip`).
+- Learn to use `apt`, `yum`, `dnf` or `pacman` (depending on distro) to find and install packages. And make sure you have `pip` to install Python-based command-line tools (a few below are easiest to install via `pip`).
 
 
 ## Everyday use


### PR DESCRIPTION
Pull request #567 has replaced `apt-get` with `apt` suggestion.