### PR TITLE
Translation improvement for term 'port(s)' in Simplified Chinese

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -560,7 +560,7 @@ mkdir empty && rsync -r --delete empty/ some-dir && rmdir some-dir
 
 - 在 Windows 10 上，你可以使用 [Bash on Ubuntu on Windows](https://msdn.microsoft.com/commandline/wsl/about)，它提供了一个熟悉的 Bash 环境，包含了不少 Unix 命令行工具。好处是它允许 Linux 上编写的程序在 Windows 上运行，而另一方面，Windows 上编写的程序却无法在 Bash 命令行中运行。
 
-- 如果你在 Windows 上主要想用 GNU 开发者工具（例如 GCC），可以考虑 [MinGW](http://www.mingw.org/) 以及它的 [MSYS](http://www.mingw.org/wiki/msys) 包，这个包提供了例如 bash，gawk，make 和 grep 的工具。MSYS 并不包含所有可以与 Cygwin 媲美的特性。当制作 Unix 工具的原生 Windows 端口时 MinGW 将特别地有用。
+- 如果你在 Windows 上主要想用 GNU 开发者工具（例如 GCC），可以考虑 [MinGW](http://www.mingw.org/) 以及它的 [MSYS](http://www.mingw.org/wiki/msys) 包，这个包提供了例如 bash，gawk，make 和 grep 的工具。MSYS 并不包含所有可以与 Cygwin 媲美的特性。当制作 Unix 工具的原生 Windows 移植版时 MinGW 将特别地有用。
 
 - 另一个在 Windows 下实现接近 Unix 环境外观效果的选项是 [Cash](https://github.com/dthree/cash)。注意在此环境下只有很少的 Unix 命令和命令行可用。
 


### PR DESCRIPTION
In general, the term 'port(s)' and its variants, like 'porting/portable', in Simplified Chinese has two different meanings under Computer Science context.
1. communication endpoint/logical identifier of a process or a type of network service.
2. adapt a software from an execution environment for which it was originally designed, to a new environment.

Therefore, in the sentence
> MinGW is particularly useful for creating native Windows ports of Unix tools.

It would be appropriate and accurate if 'ports' was translated as 2) rather than 1).  