### PR TITLE
correction typo "intéractive" -> "interactive"

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -42,7 +42,7 @@ Les objectifs sont l'*envergure* (tout est important), la *spécificité* (donne
 Chaque astuce est indispensable dans certaines situations ou fait gagner beaucoup de temps par rapport aux solutions alternatives.
 - Il est écrit pour Linux, à l'exception des sections « [Uniquement macOS](#uniquement-macos) » et « [Uniquement Windows](#uniquement-windows) ».
 Beaucoup d'items s'appliquent ou peuvent être installés sur d'autres Unices ou macOS (ou même Cygwin).
-- L'accent est mis sur l'utilisation intéractive de Bash, bien que de nombreuses astuces s'appliquent aux autres shells et à l'écriture de scripts en Bash.
+- L'accent est mis sur l'utilisation interactive de Bash, bien que de nombreuses astuces s'appliquent aux autres shells et à l'écriture de scripts en Bash.
 - Il inclut les commandes « standard » d'Unix aussi bien que celles qui nécessitent l'installation de paquets spéciaux &mdash; tant qu'ils sont suffisamment importants pour mériter d'être mentionnés.
 
 Remarques :

--- a/README-fr.md
+++ b/README-fr.md
@@ -257,9 +257,9 @@ Une alternative plus légère pour la persistance des sessions seulement est [`d
       stat -c '%A %a %n' /etc/timezone
 ```
 
-- Pour une sélection intéractive de valeurs issues de la sortie d'une commande, utilisez [`percol`](https://github.com/mooz/percol) ou [`fzf`](https://github.com/junegunn/fzf).
+- Pour une sélection interactive de valeurs issues de la sortie d'une commande, utilisez [`percol`](https://github.com/mooz/percol) ou [`fzf`](https://github.com/junegunn/fzf).
 
-- Pour intéragir avec les fichiers provenant de la sortie d'une commande (p.&nbsp;ex. `git`), utilisez `fpp` ([PathPicker](https://github.com/facebook/PathPicker)).
+- Pour interagir avec les fichiers provenant de la sortie d'une commande (p.&nbsp;ex. `git`), utilisez `fpp` ([PathPicker](https://github.com/facebook/PathPicker)).
 
 
 - Créez un simple serveur web pour partager les fichiers du répertoire courant (et ses sous-répertoires) avec `python -m SimpleHTTPServer 7777` (port 7777 et Python 2)  et `python -m http.server 7777` (port 7777 et Python 3).
@@ -297,7 +297,7 @@ Par exemple, pour convertir un document Markdown au format Word : `pandoc README
 - Si vous devez manipuler du XML, l'ancien `xmlstarlet` marche bien.
 
 - Pour le JSON, utilisez [`jq`](http://stedolan.github.io/jq/).
-Voir également [`jid`](https://github.com/simeji/jid) and [`jiq`](https://github.com/fiatjaf/jiq) pour une utilisation intéractive.
+Voir également [`jid`](https://github.com/simeji/jid) and [`jiq`](https://github.com/fiatjaf/jiq) pour une utilisation interactive.
 
 - Pour le YAML, utilisez [`shyaml`](https://github.com/0k/shyaml).
 


### PR DESCRIPTION
même en français, il n'y a pas d'accent et en plus on doit le prononcer comme si ça s'écrivait intèr avec un accent grave. Mais l'évolution du langage parlé fait qu'on fait de plus en plus l'erreur de prononcer des accents aigus à la place des accents graves.