### PR TITLE
Fix formatting inconsistency in lsmod entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ A few examples of piecing together commands:
 
 - `lshw`, `lscpu`, `lspci`, `lsusb`, `dmidecode`: hardware information, including CPU, BIOS, RAID, graphics, devices, etc.
 
-- `lsmod` and `modinfo`: List and show details of kernel modules.
+- `lsmod` and`modinfo`: list and show details of kernel modules
 
 - `fortune`, `ddate`, and `sl`: um, well, it depends on whether you consider steam locomotives and Zippy quotations "useful"
 


### PR DESCRIPTION
Fixed formatting inconsistency (capitalization and trailing period) to match the style of other entries in this section.